### PR TITLE
Fixing relative lifetime

### DIFF
--- a/src/IllimaniProfiler/IllStatisticsQueryModel.class.st
+++ b/src/IllimaniProfiler/IllStatisticsQueryModel.class.st
@@ -56,7 +56,7 @@ IllStatisticsQueryModel >> averageRelativeLifetime [
 
     | relativeLifetimes |
     relativeLifetimes := objectAllocations collect: [ :sample |
-    			(sample lifetime max: profiler totalTime) / profiler totalTime ].
+    			(sample lifetime min: profiler totalTime) / profiler totalTime ].
     ^ relativeLifetimes average
 ]
 


### PR DESCRIPTION
`max:` returns the maximum between the two values, resulting in a relative lifetime of 100% in every case.
Changed it to `min:` as I guess it was the intention.